### PR TITLE
Example for packaging a python module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,23 @@
 # Bazel
 bazel-*
 
+# Python
 __pycache__
 *.pyc
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ dependencies = [
     "pytest>=8.3.4",
     "ruff>=0.9.3",
 ]
+
+[tool.uv.workspace]
+members = ["training/python/packaging_example"]

--- a/training/python/mutable_method_arguments.py
+++ b/training/python/mutable_method_arguments.py
@@ -5,18 +5,41 @@
 
 class SomeClass:
     def __init__(self, this_is_mutable=[]):
-        self._my_list = this_is_mutable
+        self.data = this_is_mutable
 
     def __str__(self):
-        return f"SomeClass: {self._my_list}"
+        return f"SomeClass: {self.data}"
 
     def __repr__(self):
         self.__str__()
 
 
 if __name__ == "__main__":
-    a = SomeClass([1, 2, 3])
-    a.__init__()
-    b = SomeClass()
+    print(
+        " --- case 1: data gets changed outside of the class, but class member is affected:"
+    )
+    data = [1, 2, 3]
+    a = SomeClass(this_is_mutable=data)
+
+    data.append(13)
     print(f"Instance a: {a}, initialized with '[1, 2, 3]'")
-    print(f"Instance b: {b}, initialized with '[]'")
+    # Prints:
+    # Instance a: SomeClass: [1, 2, 3, 13], initialized with '[1, 2, 3]'
+
+    # -----------------------------------------------------------------------------------------
+
+    print(
+        "\n --- case 2: data is used for initializing two class instances, only one gets changed but both are affected:"
+    )
+
+    data = [23, 24, 13]
+    a = SomeClass(this_is_mutable=data)
+    b = SomeClass(this_is_mutable=data)
+
+    a.data.append(999)
+
+    print(f"Instance a: {a}")
+    print(f"Instance b: {b}")
+    # Prints:
+    # Instance a: SomeClass: [23, 24, 13, 999]'
+    # Instance b: SomeClass: [23, 24, 13, 999]'

--- a/training/python/packaging_example/LICENSE
+++ b/training/python/packaging_example/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Timo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/training/python/packaging_example/README.md
+++ b/training/python/packaging_example/README.md
@@ -1,0 +1,43 @@
+# Python Packaging Example
+
+This package is soley here for the purpose of demonstrating how to package a python package.
+The package itself is not of any relevance.
+
+Packaging done following https://packaging.python.org/en/latest/tutorials/packaging-projects/ but we used
+`uv` for it. Thus we only took the linked page as a reference.
+
+## Steps
+
+### 1. Create the package
+- create the package incl. python files
+- add readme, license and pyproject.toml (we created the latter by running `uv init` in our package folder)
+
+### 2. Build the wheel
+- run `uv build` (see https://docs.astral.sh/uv/reference/cli/#uv-build)
+
+### (optional) 3. Upload to an index
+- run `uv publish` (see https://docs.astral.sh/uv/reference/cli/#uv-publish)
+
+(For this example we did not publish anything, we just build the wheel file and verified that it can be
+installed and used again - see next step.)
+
+### 4. Test the build
+```bash
+$ mkdir test
+$ uv init
+$ uv venv
+$ source .venv/bin/activate
+$ uv pip install /home/wtn2lr/workspace/dev-playground/dist/packaging_example-0.0.1-py3-none-any.whl
+Resolved 1 package in 2ms
+Prepared 1 package in 5ms
+Installed 1 package in 13ms
+ + packaging-example==0.0.1 (from file:///home/wtn2lr/workspace/dev-playground/dist/packaging_example-0.0.1-py3-none-any.whl)
+```
+Then you can use the package as any python package:
+
+```python
+>>> from packaging_example.example import hello
+>>> hello()
+this is a dummy example.
+```
+

--- a/training/python/packaging_example/pyproject.toml
+++ b/training/python/packaging_example/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "packaging_example"
+version = "0.0.1"
+authors = [
+  { name="Timo Winterling", email="author@example.com" },
+]
+description = "This is a simple test how to package a python project."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+license = "MIT"
+license-files = ["LICENSE*"]

--- a/training/python/packaging_example/src/packaging_example/example.py
+++ b/training/python/packaging_example/src/packaging_example/example.py
@@ -1,0 +1,2 @@
+def hello():
+    print("this is a dummy example.")

--- a/training/python/pass_by_reference.py
+++ b/training/python/pass_by_reference.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
-"""Showcase why mutable default arguments are a bad idea."""
+"""Be aware that all mutable objects are passed by reference in Python.
+Knowing this, the issues below can be avoided."""
+
+import typing
 
 
 class SomeClass:
-    def __init__(self, this_is_mutable=[]):
-        self.data = this_is_mutable
+    def __init__(self, data: typing.List[int]):
+        self.data = data
 
     def __str__(self):
         return f"SomeClass: {self.data}"
@@ -19,7 +22,7 @@ if __name__ == "__main__":
         " --- case 1: data gets changed outside of the class, but class member is affected:"
     )
     data = [1, 2, 3]
-    a = SomeClass(this_is_mutable=data)
+    a = SomeClass(data=data)
 
     data.append(13)
     print(f"Instance a: {a}, initialized with '[1, 2, 3]'")
@@ -33,8 +36,8 @@ if __name__ == "__main__":
     )
 
     data = [23, 24, 13]
-    a = SomeClass(this_is_mutable=data)
-    b = SomeClass(this_is_mutable=data)
+    a = SomeClass(data=data)
+    b = SomeClass(data=data)
 
     a.data.append(999)
 


### PR DESCRIPTION
This PR introduces

* renamed `training/python/mutable_method_arguments.py` to `pass_by_reference.py` and added a few more explanations of what is happening
* Example package that demonstrates how to use `uv` for packaging a python module - taken from the packages' readme:

## Steps

### 1. Create the package
- create the package incl. python files
- add readme, license and pyproject.toml (we created the latter by running `uv init` in our package folder)

### 2. Build the wheel
- run `uv build` (see https://docs.astral.sh/uv/reference/cli/#uv-build)

### (optional) 3. Upload to an index
- run `uv publish` (see https://docs.astral.sh/uv/reference/cli/#uv-publish)

(For this example we did not publish anything, we just build the wheel file and verified that it can be
installed and used again - see next step.)

### 4. Test the build
```bash
$ mkdir test
$ uv init
$ uv venv
$ source .venv/bin/activate
$ uv pip install ./dev-playground/dist/packaging_example-0.0.1-py3-none-any.whl
Resolved 1 package in 2ms
Prepared 1 package in 5ms
Installed 1 package in 13ms
 + packaging-example==0.0.1 (from file:///<path>/dev-playground/dist/packaging_example-0.0.1-py3-none-any.whl)
```
Then you can use the package as any python package:

```python
>>> from packaging_example.example import hello
>>> hello()
this is a dummy example.
```