### PR TITLE
Twint/auto sort imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   hooks:
     - id: ruff
       name: Run ruff check
+      args: [ --fix ]
     
     - id: ruff-format
       name: Run ruff format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 # Tools config
 [tool.ruff]
 line-length = 120
+lint.extend-select = ["I"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/set-me-up.py
+++ b/set-me-up.py
@@ -6,14 +6,14 @@ Run it from the root of the repository:
 without any arguments.
 """
 
+import argparse
+import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
 from pathlib import Path
-import platform
-import json
-import argparse
 
 EXPECTED_UV_VERSION = "0.6.14"
 EXPECTED_CLANG_FORMAT_VERSION = "15"

--- a/src/docs/source/generate_index.py
+++ b/src/docs/source/generate_index.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import os
+from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DOCS_INDEX = REPO_ROOT / "src/docs/source/index.md"

--- a/src/python/image_describer/src/image_describer/__main__.py
+++ b/src/python/image_describer/src/image_describer/__main__.py
@@ -1,6 +1,8 @@
-import click
 import logging
 from pathlib import Path
+
+import click
+
 from image_describer.describer import Describer
 
 

--- a/src/python/image_describer/src/image_describer/describer.py
+++ b/src/python/image_describer/src/image_describer/describer.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 from typing import List
-from PIL import Image
-import torch
-from transformers import BlipProcessor, BlipForConditionalGeneration
 from urllib.parse import urlparse
+
 import requests
+import torch
+from PIL import Image
+from transformers import BlipForConditionalGeneration, BlipProcessor
 
 
 def is_valid_url(url: str | Path) -> bool:

--- a/src/python/image_describer/tests/test_describer.py
+++ b/src/python/image_describer/tests/test_describer.py
@@ -1,5 +1,5 @@
-from image_describer.describer import Describer
 import pytest
+from image_describer.describer import Describer
 
 
 @pytest.fixture

--- a/src/python/standalone_scripts/create_python_project_folder_structure.py
+++ b/src/python/standalone_scripts/create_python_project_folder_structure.py
@@ -2,8 +2,8 @@
 
 import argparse
 import datetime
-from pathlib import Path
 import logging
+from pathlib import Path
 
 """Script to create a boilerplate folder structure for a python project."""
 

--- a/src/python/standalone_scripts/progress_bar_for_parallel_processes.py
+++ b/src/python/standalone_scripts/progress_bar_for_parallel_processes.py
@@ -1,9 +1,10 @@
-import time
 import random
+import time
+from multiprocessing import Manager, Process
+
 from rich.console import Console
 from rich.live import Live
 from rich.table import Table
-from multiprocessing import Process, Manager
 
 """Showcasing a simple progress bar for multiple parallel processes using rich and multiprocessing.
 The task came up since tqdm does not work well with multiprocessing and the console output


### PR DESCRIPTION
This PR introduces a flag such that the imports are auto-sorted (in `pyproject.toml`) and
added the args to the pre-commit `ruff (check` to "fix" it if needed.

(pyproject.toml -> will/would be picked up by i.e. vscode
pre-commit -> ensure that if the above was not configured, it will be fixed nevertheless)